### PR TITLE
Switch to the Travis/Jitpack build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Travis build script for mineman
+
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Use Maven
+language: java
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+    - $HOME/.m2
+
+# Only re-download spigot if we don't have spigot in the repo
+before_install:
+  - if [ ! -d "$HOME/.m2/repository/org/spigotmc" ]; then ./installSpigot.sh 1.12 ; else echo "Not compiling Spigot because it is already in our maven" ; fi
+
+# Set the final name using pom-fu
+install:
+  - mvn install -DfinalName=release -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+# You fill out this section by encrypting the key using the travis utility
+# Note that the api_key is safe to put here because it is actually encrypted
+deploy:
+  provider: releases
+  api_key:
+    secure: q+vqDL6pkJoOQ0289yH034PZ2OrIpvE8lVrwnEpjKUSBkCmNhdoQ9sEymGhQAHqf5BXutPRvgsp+CcZTT/W/cOUzMreNnMv6wcu5il1tug9Dy56BJuhEP2ZuIivQjcojT8ALNg/kiXpo+ZVVXfIRaWOz+xlH3ldB2S5eaQwUZadE8KDW3sMKVj+C9HkWTXkGvUjM286MM5DBL1uuUB8NoPVW9EU6e7XI6kX207xfG3TUJ/Nvaf43mRvEPhzXgdWrpU4ldmdfAA6q8W4Cykdw5Cbs82Ven5avGo15PJyz1ZV/SaETGgobSaE/+ntyCNrvDZT7UL6CqS7EC/bgYiDQSbR6zr+HiV4dFVi19KEjaaVu8Jro6UhLsLrL7aL1xqPTX04ZY6wdeLywOCaLj6q4BaVKIW9g1dr+j+9HCGGR+cDlzZouFZxuOqixsnMh1bUQ4kjIkxBtFzpLUfrolSyMDyjiLDjuVPcdRWOdfVochSCW9mOWyGHvkvGMJefb8Ia4/If/++e+n4i9tW7QqOmsvfazWGfh0bjcXw5ua8wiMsBpIT1jrNrhCIq9d9suyQR0C6B0P3EyHhOYxt6Efd0/sqw3OvgMrteMS2+qJNjN8omnMsBtZrUonfoAnpRD9nEJC75bgEzZBjKy813SRsdA2odbpqMCenXtJkXpM+NBAWw=
+  file: target/release.jar
+  skip_cleanup: true
+  # Modify this to build on every commit
+  on:
+    tags: true

--- a/installSpigot.sh
+++ b/installSpigot.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+mkdir -p $HOME/spigot-build
+pushd $HOME/spigot-build
+echo "Downloading Spigot Build Tools for minecraft version $1"
+wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -O $HOME/spigot-build/BuildTools.jar
+git config --global --unset core.autocrlf
+echo "Building Spigot using Spigot Build Tools for minecraft version $1 (this might take a while)"
+java -Xmx1500M -jar BuildTools.jar --rev $1 | grep Installing
+echo "Installing Spigot jar in Maven"
+mvn install:install-file -Dfile=$HOME/spigot-build/spigot-$1.jar -Dpackaging=jar -DpomFile=$HOME/spigot-build/Spigot/Spigot-Server/pom.xml
+echo "Installing CraftBukkit jar in Maven"
+mvn install:install-file -Dfile=$HOME/spigot-build/craftbukkit-$1.jar -Dpackaging=jar -DpomFile=$HOME/spigot-build/CraftBukkit/pom.xml
+popd

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,8 @@
+# Download the version, assuming it is a tag
+# Just fail if it doesn't download
+before_install:
+  - echo "Downloading release jar for version $VERSION from `echo $GROUP | grep -oP '(?<=git\.user\.).*$'`/$ARTIFACT"
+  - wget https://github.com/`echo $GROUP | grep -oP '(?<=git\.user\.).*$'`/$ARTIFACT/releases/download/$VERSION/release.jar -O release.jar
+
+install:
+  - mvn install:install-file -Dfile=release.jar -DpomFile=pom.xml

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,8 +1,11 @@
 # Download the version, assuming it is a tag
 # Just fail if it doesn't download
 before_install:
-  - echo "Downloading release jar for version $VERSION from `echo $GROUP | grep -oP '(?<=com\.github\.).*$'`/$ARTIFACT"
-  - wget https://github.com/`echo $GROUP | grep -oP '(?<=com\.github\.).*$'`/$ARTIFACT/releases/download/$VERSION/release.jar -O release.jar
+  - echo $GROUP
+  - echo $ARTIFACT
+  - echo $VERSION
+  - echo "Downloading release jar for version $VERSION from `echo $GROUP | grep -oP '(?<=com\.github\.)\w+'`/NameLayer"
+  - wget https://github.com/`echo $GROUP | grep -oP '(?<=com\.github\.)\w+'`/NameLayer/releases/download/$VERSION/release.jar -O release.jar
 
 install:
-  - mvn install:install-file -Dfile=release.jar -DpomFile=pom.xml
+  - mvn install:install-file -Dfile=release.jar -DartifactId=$ARTIFACT -DgroupId=$GROUP -Dversion=$VERSION -Dpackaging=jar

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,8 +1,8 @@
 # Download the version, assuming it is a tag
 # Just fail if it doesn't download
 before_install:
-  - echo "Downloading release jar for version $VERSION from `echo $GROUP | grep -oP '(?<=git\.user\.).*$'`/$ARTIFACT"
-  - wget https://github.com/`echo $GROUP | grep -oP '(?<=git\.user\.).*$'`/$ARTIFACT/releases/download/$VERSION/release.jar -O release.jar
+  - echo "Downloading release jar for version $VERSION from `echo $GROUP | grep -oP '(?<=com\.github\.).*$'`/$ARTIFACT"
+  - wget https://github.com/`echo $GROUP | grep -oP '(?<=com\.github\.).*$'`/$ARTIFACT/releases/download/$VERSION/release.jar -O release.jar
 
 install:
   - mvn install:install-file -Dfile=release.jar -DpomFile=pom.xml

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -4,8 +4,8 @@ before_install:
   - echo $GROUP
   - echo $ARTIFACT
   - echo $VERSION
-  - echo "Downloading release jar for version $VERSION from `echo $GROUP | grep -oP '(?<=com\.github\.)\w+'`/NameLayer"
-  - wget https://github.com/`echo $GROUP | grep -oP '(?<=com\.github\.)\w+'`/NameLayer/releases/download/$VERSION/release.jar -O release.jar
+  - echo "Downloading release jar for version $VERSION from `echo $GROUP | grep -oP '(?<=com\.github\.)\w+'`/CivModCore"
+  - wget https://github.com/`echo $GROUP | grep -oP '(?<=com\.github\.)\w+'`/CivModCore/releases/download/$VERSION/release.jar -O release.jar
 
 install:
   - mvn install:install-file -Dfile=release.jar -DartifactId=$ARTIFACT -DgroupId=$GROUP -Dversion=$VERSION -Dpackaging=jar

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 	<url>https://github.com/DevotedMC/CivModCore/</url>
 
 	<properties>
+		<finalName>${project.artifactId}-${project.version}</finalName>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
@@ -26,9 +27,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>vg.civcraft.mc.mercury</groupId>
+			<groupId>com.github.CivClassic</groupId>
 			<artifactId>Mercury</artifactId>
-			<version>1.2.20</version>
+			<version>master-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -42,12 +43,14 @@
 
 	<repositories>
 		<repository>
-			<id>devoted-repo</id>
-			<url>https://build.devotedmc.com/plugin/repository/everything/</url>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
 		</repository>
 	</repositories>
 
 	<build>
+		<!-- Override the final name for travis if set -->
+		<finalName>${finalName}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -76,24 +79,6 @@
 						<goals>
 							<goal>shade</goal>
 						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>2.17</version>
-				<configuration>
-					<configLocation>https://build.devotedmc.com/job/Style-guide-master/lastSuccessfulBuild/artifact/src/main/resources/devoted_checks.xml</configLocation>
-					<consoleOutput>true</consoleOutput>
-				</configuration>
-				<executions>
-					<execution>
-						<id>checkstyle</id>
-						<goals>
-							<goal>checkstyle</goal>
-						</goals>
-						<phase>prepare-package</phase>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Please review this commit. [How this duct tape works](https://gist.github.com/Lazersmoke/cb8445b7bd7b113b0244fe0fae1ea7ab), including instructions on how to fill in the key correctly.
Also, this grabs the latest version of Mercury from the `master` branch on CivClassic Github. You should make a Github release on that repo and change the version number in the pom appropriately (from `master-SNAPSHOT` to the actual version).

Here are the individual commits this commit was squashed from:

Switch to jitpack

Re-add spigot repo

Speculative fix for spigot issue

Attempting to do Travis CI

Apparently Travis automatically creates cached directories

Attempted to add git release functionality

Fixed Travis build not actually working after the first time

Speculative fix for build issue

Apparently pushd/popd isn't a thing in sh

Also make the directory

Added jitpack.yml with non-caching builds

Re-enable caching for travis build

Changed to only release when there is an actual tag

Apparently caching breaks things?

More speculative fixes

Switch to caching maven instead of build tools

Modified jitpack to test configuration

Tweak jitpack

Polished the scripts, mostly ready to deploy

Generalize and polish scripts more

Fixed travis naming issue (hopefully)

Final cleanup for Travis/jitpack