### PR TITLE
Add Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# Travis build script for mineman
+
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Use Maven
+language: java
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+    - $HOME/.m2
+
+# Only re-download spigot if we don't have spigot in the repo
+before_install:
+  - if [ ! -d "$HOME/.m2/repository/org/spigotmc" ]; then ./installSpigot.sh 1.12 ; else echo "Not compiling Spigot because it is already in our maven" ; fi

--- a/installSpigot.sh
+++ b/installSpigot.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+mkdir -p $HOME/spigot-build
+pushd $HOME/spigot-build
+echo "Downloading Spigot Build Tools for minecraft version $1"
+wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar -O $HOME/spigot-build/BuildTools.jar
+git config --global --unset core.autocrlf
+echo "Building Spigot using Spigot Build Tools for minecraft version $1 (this might take a while)"
+java -Xmx1500M -jar BuildTools.jar --rev $1 | grep Installing
+echo "Installing Spigot jar in Maven"
+mvn install:install-file -Dfile=$HOME/spigot-build/spigot-$1.jar -Dpackaging=jar -DpomFile=$HOME/spigot-build/Spigot/Spigot-Server/pom.xml
+echo "Installing CraftBukkit jar in Maven"
+mvn install:install-file -Dfile=$HOME/spigot-build/craftbukkit-$1.jar -Dpackaging=jar -DpomFile=$HOME/spigot-build/CraftBukkit/pom.xml
+popd


### PR DESCRIPTION
This is the version without any jitpack stuff, so it still relies on devoted build server, just with a PR builder bot. If merged, Teal needs to enable Travis CI for this repo by clicking the "Activate" button [here](https://travis-ci.org/CivClassic/CivModCore).

[Here's this exact commit's build passing on Travis](https://travis-ci.org/Lazersmoke/CivModCore/builds/326482317).