### PR TITLE
Fix command completions

### DIFF
--- a/src/main/java/vg/civcraft/mc/civmodcore/api/MaterialAPI.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/api/MaterialAPI.java
@@ -10,8 +10,8 @@ import org.bukkit.Tag;
 /**
  * <p>See <a href="https://github.com/Protonull/BukkitReport/tree/master/reports">BukkitReports</a>.</p>
  *
+ * See also:
  * <ul>
- *     <label>See also:</label>
  *     <li>{@link SpawnEggAPI SpawnEggAPI}</li>
  *     <li>{@link TreeTypeAPI TreeTypeAPI}</li>
  * </ul>

--- a/src/test/java/vg/civcraft/mc/civmodcore/commands/TrieTest.java
+++ b/src/test/java/vg/civcraft/mc/civmodcore/commands/TrieTest.java
@@ -1,0 +1,41 @@
+package vg.civcraft.mc.civmodcore.commands;
+
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import vg.civcraft.mc.civmodcore.command.Trie;
+
+public class TrieTest {
+	private final Trie trie = Trie.getNewTrie();
+
+	{
+		trie.insert("advanced cauldron");
+		trie.insert("aesthetics factory");
+		trie.insert("bakery");
+		trie.insert("basic cauldron");
+	}
+
+	@Test
+	public void testNoArgs() {
+		List<String> match = trie.match(new String[0]);
+		Assert.assertEquals(List.of("advanced cauldron", "aesthetics factory", "bakery", "basic cauldron"), match);
+	}
+
+	@Test
+	public void testOneArg() {
+		List<String> match = trie.match(new String[] {"a"});
+		Assert.assertEquals(List.of("advanced cauldron", "aesthetics factory"), match);
+	}
+
+	@Test
+	public void testOneAndEmptyArg() {
+		List<String> match = trie.match(new String[] {"advanced", ""});
+		Assert.assertEquals(List.of("cauldron"), match);
+	}
+
+	@Test
+	public void testTwoArgs() {
+		List<String> match = trie.match(new String[] {"advanced", "c"});
+		Assert.assertEquals(List.of("cauldron"), match);
+	}
+}


### PR DESCRIPTION
Minecraft doesn't work as you would expect for multi-word command completions.
If you type `/fm advanced c<TAB>`, you would expect this to autocomplete to `/fm advanced cauldron` but it actually autocompletes to `/fm advanced advanced cauldron`.
This PR will fix that issue, but it depends on a FactoryMod change as well because the API has changed. Also includes tests.