### PR TITLE
Remove unnecessary config reload

### DIFF
--- a/src/main/java/vg/civcraft/mc/civmodcore/CoreConfigManager.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/CoreConfigManager.java
@@ -37,7 +37,6 @@ public class CoreConfigManager {
 	public final boolean parse() {
 		this.plugin.info(ChatColor.BLUE + "Parsing config.");
 		this.plugin.saveDefaultConfig();
-		this.plugin.reloadConfig();
 		FileConfiguration config = this.plugin.getConfig();
 		// Parse debug value
 		this.debug = config.getBoolean("debug", false);


### PR DESCRIPTION
The just-saved default config wont have suddenly changed between the save and the reload. All this does is force every serialisable object to be re-initialised, probably creating a whole bunch of unnecessary database connections, item stacks, etc.