### PR TITLE
Add MoreObjectUtils

### DIFF
--- a/src/main/java/vg/civcraft/mc/civmodcore/util/MoreObjectUtils.java
+++ b/src/main/java/vg/civcraft/mc/civmodcore/util/MoreObjectUtils.java
@@ -1,0 +1,26 @@
+package vg.civcraft.mc.civmodcore.util;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+/**
+ * Utility class that fills in the gaps of {@link ObjectUtils}.
+ *
+ * @author Protonull
+ */
+public final class MoreObjectUtils {
+
+	/**
+	 * Determines whether two things are equal based on their respective hash codes. This is obviously less accurate
+	 * than {@link Object#equals(Object)}, however this can be used to, for example, test if an object has been changed.
+	 *
+	 * @param <L> The left hand object type.
+	 * @param <R> The right hand object type.
+	 * @param lhs The left hand object.
+	 * @param rhs THe right hand object.
+	 * @return Returns whether the left hand and right hand objects have matching hashes.
+	 */
+	public static <L, R> boolean hashEquals(final L lhs, final R rhs) {
+		return lhs == rhs || (!(lhs == null || rhs == null) && lhs.hashCode() == rhs.hashCode());
+	}
+
+}


### PR DESCRIPTION
Adds a new utility class specifically for objects, which currently only has one API: `hashEquals(lhs, rhs)` which does a quick and dirty equals check on the two given objects.